### PR TITLE
add prettier precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,14 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.ts": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "private": true,
   "dependencies": {
@@ -35,6 +42,7 @@
     "@types/jasmine": "2.5.47",
     "@types/node": "~7.0.18",
     "codelyzer": "~3.0.1",
+    "husky": "^0.13.4",
     "jasmine-core": "~2.6.1",
     "jasmine-spec-reporter": "~4.1.0",
     "karma": "~1.7.0",
@@ -43,6 +51,8 @@
     "karma-coverage-istanbul-reporter": "^1.2.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "lint-staged": "^3.6.1",
+    "prettier": "^1.4.4",
     "protractor": "~5.1.1",
     "ts-node": "~3.0.4",
     "tslint": "~5.2.0",


### PR DESCRIPTION
This will only run on .ts files that are being committed with the precommit script. If you don't like the default prettier options you can add opts to the prettier cmd in the `lint-staged` object in package.json